### PR TITLE
bump runtime

### DIFF
--- a/org.tabos.twofun.json
+++ b/org.tabos.twofun.json
@@ -1,13 +1,13 @@
 {
     "app-id": "org.tabos.twofun",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "twofun",
     "finish-args": [
         "--share=network",
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland"
     ],
     "modules": [


### PR DESCRIPTION
3.36 is deprecated & we should use fallback-x11 instead of x11 for apps that supports wayland 

cc @janbrummer 